### PR TITLE
Enable leaking owned memory from std::vector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,22 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+option(LEAKY_USE_ASAN "Enable AddressSanitizer" OFF)
+option(LEAKY_USE_UBSAN "Enable UndefinedBehaviorSanitizer" OFF)
+
+set(SANITIZER_FLAGS "")
+if(LEAKY_USE_ASAN)
+    set(SANITIZER_FLAGS "-fno-omit-frame-pointer -fsanitize=address")
+elseif(LEAKY_USE_UBSAN)
+    set(SANITIZER_FLAGS "-fno-omit-frame-pointer -fsanitize=undefined")
+endif()
+
+if(SANITIZER_FLAGS)
+    message(STATUS "Enabling sanitizers with flags: ${SANITIZER_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SANITIZER_FLAGS}")
+    set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} ${SANITIZER_FLAGS}")
+endif()
+
 include(GNUInstallDirs)
 include(CTest)
 

--- a/include/leakyvec/leakyvec.hpp
+++ b/include/leakyvec/leakyvec.hpp
@@ -1,7 +1,31 @@
 #pragma once
+#include <tuple>
 #include <vector>
 
 namespace leaky {
+
+namespace detail {
+    template<typename T, typename Alloc = typename std::vector<T>::allocator_type>
+    struct VecWrapper
+    {
+        using pointer = typename std::vector<T, Alloc>::pointer;
+        std::vector<T, Alloc> inner;
+
+        [[nodiscard]] pointer get_data_start() noexcept { return inner.data(); }
+
+        [[nodiscard]] pointer get_data_end() noexcept
+        {
+            // One past the end of the initialized data
+            return inner.data() + inner.size();
+        }
+
+        [[nodiscard]] pointer get_capacity_end() noexcept
+        {
+            // One past the end of the allocated capacity
+            return inner.data() + inner.capacity();
+        }
+    };
+}  // namespace detail
 
 /// @brief a wrapper around std::vector that allows leaking its contents and transfering ownership
 ///
@@ -11,7 +35,7 @@ template<typename T, typename Alloc = typename std::vector<T>::allocator_type>
 class Vec
 {
   private:
-    std::vector<T, Alloc> m_inner;
+    detail::VecWrapper<T, Alloc> m_inner;
 
   public:
     /// @brief Create a leaky Vec from a std::vector. Takes exclusive ownership.

--- a/include/leakyvec/leakyvec.hpp
+++ b/include/leakyvec/leakyvec.hpp
@@ -24,6 +24,94 @@ namespace detail {
             // One past the end of the allocated capacity
             return inner.data() + inner.capacity();
         }
+
+        static VecWrapper<T, Alloc>
+        unsafe_from_parts(std::tuple<pointer, size_t, size_t, Alloc> parts) noexcept
+        {
+            return unsafe_from_parts(
+                std::get<0>(parts), std::get<1>(parts), std::get<2>(parts), std::get<3>(parts));
+        }
+
+        static VecWrapper<T, Alloc> unsafe_from_parts(pointer data_start,
+                                                      size_t size,
+                                                      size_t capacity,
+                                                      Alloc alloc = Alloc()) noexcept
+        {
+            VecWrapper<T, Alloc> wrapper{std::vector<T, Alloc>(alloc)};
+            wrapper.unsafe_set_data_start(data_start);
+            wrapper.unsafe_set_size(size);
+            wrapper.unsafe_set_capacity(capacity);
+            return wrapper;
+        }
+
+        [[nodiscard]] std::tuple<pointer, size_t, size_t, Alloc> leak_into_parts() noexcept
+        {
+            pointer data_start = inner.data();
+            const auto size = inner.size();
+            const auto capacity = inner.capacity();
+            const auto retval = std::make_tuple(data_start, size, capacity, inner.get_allocator());
+
+            unsafe_set_data_start(nullptr);
+            unsafe_set_size(0);
+            unsafe_set_capacity(0);
+
+            return retval;
+        }
+
+        /// @brief Set the data start pointer to a new value
+        ///
+        /// @warning This very likely invalidates the data_end and capacity_end pointers!
+        void unsafe_set_data_start(pointer new_start) noexcept
+        {
+            static_assert(sizeof(inner) >= 3 * sizeof(pointer));
+            // inner._M_impl._M_start = new_start;
+        }
+
+        /// @brief Set the size of the vector to a new value
+        ///
+        /// @warning This may invalidate the capacity_end pointer!
+        /// @note This requires the data_start pointer be valid.
+        void unsafe_set_size(size_t new_size) noexcept
+        {
+            // std::vector is not guaranteed to be 3 words if it has a non-default allocator.
+            // Further, the _M_start pointer isn't the first member in such a case. Unfortunately,
+            // the allocator stuff at the beginning of _Vector_impl isn't the same size as the Alloc
+            // template parameter, so we can't just assert that
+            //
+            //     static_assert(sizeof(inner) == sizeof(Alloc) + 3 * sizeof(pointer));
+            static_assert(sizeof(inner) >= 3 * sizeof(pointer));
+
+            // NOTE: In libstdc++, std::vector is defined like
+            //
+            //     struct vector : _Vector_base {};
+            //
+            //     struct _Vector_base {
+            //         _Vector_impl _M_impl;
+            //     };
+            //     struct _Vector_impl : _Tp_alloc_type, _Vector_impl_data {};
+            //     struct _Tp_alloc_type { ... }; // allocator, if present
+            //     struct _Vector_impl_data {
+            //         pointer _M_start;
+            //         pointer _M_finish;
+            //         pointer _M_end_of_storage;
+            //     };
+            //
+            // TODO: Look at MSVC and libc++ implementations as well. Specialize the implementation
+            // if necessary, otherwise at a minimum add enough static_asserts or unit tests to
+            // ensure the layout is as expected.
+
+            // inner._M_impl._M_finish = inner._M_impl._M_start + new_size;
+        }
+
+        /// @brief Set the capacity of the vector to a new value
+        ///
+        /// @warning This may allow writing beyond the allocated memory if used incorrectly!
+        /// @note This requires the data_start pointer be valid.
+        void unsafe_set_capacity(size_t new_capacity) noexcept
+        {
+            static_assert(sizeof(inner) >= 3 * sizeof(pointer));
+            // inner._M_impl._M_end_of_storage = inner._M_impl._M_start + new_capacity;
+        }
     };
 }  // namespace detail
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(GTest REQUIRED)
 
-add_executable(leakyvec-tests test-allocators.cpp)
+add_executable(leakyvec-tests test-allocators.cpp test-vec-wrapper.cpp)
 target_compile_features(leakyvec-tests INTERFACE cxx_std_17)
 target_link_libraries(leakyvec-tests PUBLIC leakyvec)
 target_link_libraries(leakyvec-tests PRIVATE GTest::gmock_main)

--- a/tests/test-vec-wrapper.cpp
+++ b/tests/test-vec-wrapper.cpp
@@ -1,0 +1,50 @@
+#include "log-allocator.hpp"
+#include "mock-allocator.hpp"
+
+#include <leakyvec/leakyvec.hpp>
+
+#include <gmock/gmock.h>
+
+TEST(VecWrapperTests, uint8_t)
+{
+    auto v = std::vector<uint8_t, testing::LogAllocator<uint8_t>>{1, 2, 3, 4};
+    v.reserve(10);
+
+    ASSERT_EQ(v.size(), 4);
+    ASSERT_EQ(v.capacity(), 10);
+
+    leaky::detail::VecWrapper<uint8_t, testing::LogAllocator<uint8_t>> wrapper{std::move(v)};
+
+    const auto* data_start = wrapper.get_data_start();
+    ASSERT_EQ(data_start, wrapper.inner.data());
+
+    const auto* one_past_data_end = wrapper.get_data_end();
+    const auto* data_end = one_past_data_end - 1;
+    ASSERT_EQ(data_end[0], 4);
+    ASSERT_EQ(one_past_data_end - data_start, 4);
+
+    const auto* capacity_end = wrapper.get_capacity_end();
+    ASSERT_EQ(capacity_end - data_start, 10);
+}
+
+TEST(VecWrapperTests, uint64_t)
+{
+    auto v = std::vector<uint64_t>{1, 2, 3, 4};
+    v.reserve(10);
+
+    ASSERT_EQ(v.size(), 4);
+    ASSERT_EQ(v.capacity(), 10);
+
+    leaky::detail::VecWrapper<uint64_t> wrapper{std::move(v)};
+
+    const auto* data_start = wrapper.get_data_start();
+    ASSERT_EQ(data_start, wrapper.inner.data());
+
+    const auto* one_past_data_end = wrapper.get_data_end();
+    const auto* data_end = one_past_data_end - 1;
+    ASSERT_EQ(data_end[0], 4);
+    ASSERT_EQ(one_past_data_end - data_start, 4);
+
+    const auto* capacity_end = wrapper.get_capacity_end();
+    ASSERT_EQ(capacity_end - data_start, 10);
+}

--- a/tests/test-vec-wrapper.cpp
+++ b/tests/test-vec-wrapper.cpp
@@ -48,3 +48,68 @@ TEST(VecWrapperTests, uint64_t)
     const auto* capacity_end = wrapper.get_capacity_end();
     ASSERT_EQ(capacity_end - data_start, 10);
 }
+
+TEST(VecWrapperTests, Setters)
+{
+    auto v = std::vector<int>{1, 2, 3, 4};
+    v.reserve(10);
+
+    const auto original_capacity = v.capacity();
+    ASSERT_EQ(original_capacity, 10);
+    ASSERT_EQ(v.size(), 4);
+
+    auto wrapper = leaky::detail::VecWrapper<int>{std::move(v)};
+    auto* original_data_start = wrapper.get_data_start();
+    const auto* original_data_end = wrapper.get_data_end();
+    const auto* original_capacity_end = wrapper.get_capacity_end();
+
+    wrapper.unsafe_set_size(3);
+    ASSERT_EQ(wrapper.inner.size(), 3);
+
+    // Would introduce a memory leak if we left this dangling
+    wrapper.unsafe_set_capacity(3);
+    ASSERT_EQ(wrapper.inner.capacity(), 3);
+
+    wrapper.unsafe_set_capacity(original_capacity);
+    ASSERT_EQ(wrapper.inner.capacity(), original_capacity);
+    ASSERT_EQ(wrapper.get_data_end(), original_data_end - 1);
+    ASSERT_EQ(wrapper.get_capacity_end(), original_capacity_end);
+
+    // Can't deallocate without an explosion, so we have to put it back
+    wrapper.unsafe_set_data_start(original_data_start + 1);
+    ASSERT_EQ(wrapper.inner.data(), original_data_start + 1);
+    ASSERT_EQ(wrapper.get_data_start(), original_data_start + 1);
+
+    wrapper.unsafe_set_data_start(original_data_start);
+}
+
+TEST(VecWrapperTests, ToAndFromParts)
+{
+    testing::MockAllocator<int> alloc;
+    EXPECT_CALL(*alloc.mock, allocate(4)).Times(1);                 // initial allocation
+    EXPECT_CALL(*alloc.mock, deallocate(testing::_, 4)).Times(1);   // deallocate
+    EXPECT_CALL(*alloc.mock, allocate(10)).Times(1);                // resize
+    EXPECT_CALL(*alloc.mock, deallocate(testing::_, 10)).Times(1);  // drop
+
+    auto v = std::vector<int, testing::MockAllocator<int>>{{1, 2, 3, 4}, alloc};
+    v.reserve(10);
+
+    auto wrapper = leaky::detail::VecWrapper<int, testing::MockAllocator<int>>{std::move(v)};
+    const auto* original_data_start = wrapper.get_data_start();
+    const auto* original_data_end = wrapper.get_data_end();
+    const auto* original_capacity_end = wrapper.get_capacity_end();
+
+    // Orphan the vector's memory; would leak if we left this dangling
+    auto parts = wrapper.leak_into_parts();
+
+    // Reconstruct the vector from the original memory parts; should not do any more allocations,
+    // and should have the exact same pointers as before;
+    auto new_wrapper =
+        leaky::detail::VecWrapper<int, testing::MockAllocator<int>>::unsafe_from_parts(parts);
+
+    // BUG: These assertions fail
+    ASSERT_EQ(new_wrapper.get_data_start(), original_data_start);
+    ASSERT_EQ(new_wrapper.get_data_end(), original_data_end);
+    ASSERT_EQ(new_wrapper.get_capacity_end(), original_capacity_end);
+    // BUG: This test doesn't exit?! Maybe shenanigans due to the mock allocator during destruction?
+}


### PR DESCRIPTION
Closes #8.

TODO:

* [ ] Public API in `leaky::Vec`
* [ ] Usage example in README
* [ ] Fix failing tests
* [ ] Polish and documentation
* [ ] (out-of-scope) - `std::vector` layout assertions
* [ ] (out-of-scope) - test against multiple standard library implementations
  * [ ] `libstdc++`
  * [ ] `libc++`
  * [ ] MSVC
* [ ] (out-of-scope) - GitHub CI
* [ ] (out-of-scope) - ASAN / MSAN in CI and locally