### PR TITLE
Implement VecWrapper internal std::vector manipulation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,19 @@ This is mostly just an experiment to see if it's possible; I'm not sure I'd reco
 ```cpp
 #include <leakyvec/leakyvec.hpp>
 
-// TODO
+auto vec = std::vector<int>{1, 2, 3, 4};
+auto leaky_vec = leaky::Vec<int>(std::move(vec));
+auto parts = leaky_vec.leak();
+
+// Either transfer ownership back to a std::vector like so:
+auto leaky_vec2 = leaky::Vec<int>::from_parts(parts);
+auto vec2 = leaky_vec2.take();
+
+// ... or manually delete the leaked memory with the allocator:
+auto [data, size, capacity, allocator] = parts;
+alloc.deallocate(data, capacity);
+
+// But don't do both! :)
 ```
 
 ## Demo transferring memory ownership from C++ to Rust
@@ -49,3 +61,8 @@ cmake --build build --parallel
 ctest --test-dir build          # Use CTest
 ./build/tests/leakyvec-tests    # Run the test binary directly
 ```
+
+### How to run the tests with ASAN / UBSAN?
+
+Add `-DLEAKY_USE_ASAN=ON` or `-DLEAKY_USE_UBSAN=ON` to the CMake command above. You need to delete
+the build directory and reconfigure CMake after changing these options.

--- a/include/leakyvec/leakyvec.hpp
+++ b/include/leakyvec/leakyvec.hpp
@@ -1,6 +1,18 @@
 #pragma once
 #include <tuple>
+#include <type_traits>
 #include <vector>
+
+#ifdef NDEBUG
+    #define LEAKY_DEBUG_ASSERT(x)                                                                  \
+        do                                                                                         \
+        {                                                                                          \
+            static_cast<void>(x);                                                                  \
+        } while (0)
+#else
+    #include <cassert>
+    #define LEAKY_DEBUG_ASSERT(x) assert(x)
+#endif
 
 namespace leaky {
 
@@ -11,18 +23,109 @@ namespace detail {
         using pointer = typename std::vector<T, Alloc>::pointer;
         std::vector<T, Alloc> inner;
 
+        // NOTE: In libstdc++, std::vector is defined like
+        //
+        //     struct vector : _Vector_base {};
+        //
+        //     struct _Vector_base {
+        //         _Vector_impl _M_impl;
+        //     };
+        //     struct _Vector_impl : _Tp_alloc_type, _Vector_impl_data {};
+        //     struct _Tp_alloc_type { ... }; // allocator, if present, zero-sized otherwise
+        //     struct _Vector_impl_data {
+        //         pointer _M_start;
+        //         pointer _M_finish;
+        //         pointer _M_end_of_storage;
+        //     };
+        //
+        // TODO: Look at MSVC and libc++ implementations as well!
+        template<typename A = Alloc, typename D = std::allocator<T>>
+        [[nodiscard]] constexpr std::enable_if_t<std::is_same_v<A, D>, size_t>
+        get_data_ptr_offset() const noexcept
+        {
+            // The default allocator is not stored in the std::vector
+            static_assert(sizeof(inner) == 3 * sizeof(pointer));
+            return 0;
+        }
+
+        template<typename A = Alloc, typename D = std::allocator<T>>
+        [[nodiscard]] constexpr std::enable_if_t<!std::is_same_v<A, D>, size_t>
+        get_data_ptr_offset() const noexcept
+        {
+            // Any non-default allocators are stored at the beginning of the std::vector
+            static_assert(sizeof(inner) == sizeof(Alloc) + 3 * sizeof(pointer));
+            // Return the offset in words, not in bytes, because when we do pointer arithmetic, it
+            // increments by sizeof(pointer), not in bytes.
+            return sizeof(Alloc) / sizeof(pointer);
+        }
+
         [[nodiscard]] pointer get_data_start() noexcept { return inner.data(); }
+        [[nodiscard]] pointer* get_data_start_ptr() noexcept
+        {
+            // The offset is implementation defined, and depends on whether the std::vector uses the
+            // default allocator.
+            auto* ptr = reinterpret_cast<pointer*>(&inner) + get_data_ptr_offset() + 0;
+            LEAKY_DEBUG_ASSERT(get_data_start() == *ptr);
+            return ptr;
+        };
+
+        /// @brief Set the data start pointer to a new value
+        ///
+        /// @warning This very likely invalidates the data_end and capacity_end pointers!
+        void unsafe_set_data_start(pointer new_start) noexcept
+        {
+            // inner._M_impl._M_start = new_start;
+            auto* data_start_ptr = get_data_start_ptr();
+            *data_start_ptr = new_start;
+            LEAKY_DEBUG_ASSERT(inner.data() == new_start);
+        }
 
         [[nodiscard]] pointer get_data_end() noexcept
         {
             // One past the end of the initialized data
-            return inner.data() + inner.size();
+            return get_data_start() + inner.size();
+        }
+        [[nodiscard]] pointer* get_data_end_ptr() noexcept
+        {
+            auto* ptr = reinterpret_cast<pointer*>(&inner) + get_data_ptr_offset() + 1;
+            LEAKY_DEBUG_ASSERT(get_data_end() == *ptr);
+            return ptr;
+        }
+
+        /// @brief Set the size of the vector to a new value
+        ///
+        /// @warning This may invalidate the capacity_end pointer!
+        /// @note This requires the data_start pointer be valid.
+        void unsafe_set_size(size_t new_size) noexcept
+        {
+            // inner._M_impl._M_finish = inner._M_impl._M_start + new_size;
+            auto* data_end_ptr = get_data_end_ptr();
+            *data_end_ptr = get_data_start() + new_size;
+            LEAKY_DEBUG_ASSERT(inner.size() == new_size);
         }
 
         [[nodiscard]] pointer get_capacity_end() noexcept
         {
             // One past the end of the allocated capacity
-            return inner.data() + inner.capacity();
+            return get_data_start() + inner.capacity();
+        }
+        [[nodiscard]] pointer* get_capacity_end_ptr() noexcept
+        {
+            auto* ptr = reinterpret_cast<pointer*>(&inner) + get_data_ptr_offset() + 2;
+            LEAKY_DEBUG_ASSERT(get_capacity_end() == *ptr);
+            return ptr;
+        }
+
+        /// @brief Set the capacity of the vector to a new value
+        ///
+        /// @warning This may allow writing beyond the allocated memory if used incorrectly!
+        /// @note This requires the data_start pointer be valid.
+        void unsafe_set_capacity(size_t new_capacity) noexcept
+        {
+            // inner._M_impl._M_end_of_storage = inner._M_impl._M_start + new_capacity;
+            auto* capacity_end_ptr = get_capacity_end_ptr();
+            *capacity_end_ptr = get_data_start() + new_capacity;
+            LEAKY_DEBUG_ASSERT(inner.capacity() == new_capacity);
         }
 
         static VecWrapper<T, Alloc>
@@ -57,61 +160,6 @@ namespace detail {
 
             return retval;
         }
-
-        /// @brief Set the data start pointer to a new value
-        ///
-        /// @warning This very likely invalidates the data_end and capacity_end pointers!
-        void unsafe_set_data_start(pointer new_start) noexcept
-        {
-            static_assert(sizeof(inner) >= 3 * sizeof(pointer));
-            // inner._M_impl._M_start = new_start;
-        }
-
-        /// @brief Set the size of the vector to a new value
-        ///
-        /// @warning This may invalidate the capacity_end pointer!
-        /// @note This requires the data_start pointer be valid.
-        void unsafe_set_size(size_t new_size) noexcept
-        {
-            // std::vector is not guaranteed to be 3 words if it has a non-default allocator.
-            // Further, the _M_start pointer isn't the first member in such a case. Unfortunately,
-            // the allocator stuff at the beginning of _Vector_impl isn't the same size as the Alloc
-            // template parameter, so we can't just assert that
-            //
-            //     static_assert(sizeof(inner) == sizeof(Alloc) + 3 * sizeof(pointer));
-            static_assert(sizeof(inner) >= 3 * sizeof(pointer));
-
-            // NOTE: In libstdc++, std::vector is defined like
-            //
-            //     struct vector : _Vector_base {};
-            //
-            //     struct _Vector_base {
-            //         _Vector_impl _M_impl;
-            //     };
-            //     struct _Vector_impl : _Tp_alloc_type, _Vector_impl_data {};
-            //     struct _Tp_alloc_type { ... }; // allocator, if present
-            //     struct _Vector_impl_data {
-            //         pointer _M_start;
-            //         pointer _M_finish;
-            //         pointer _M_end_of_storage;
-            //     };
-            //
-            // TODO: Look at MSVC and libc++ implementations as well. Specialize the implementation
-            // if necessary, otherwise at a minimum add enough static_asserts or unit tests to
-            // ensure the layout is as expected.
-
-            // inner._M_impl._M_finish = inner._M_impl._M_start + new_size;
-        }
-
-        /// @brief Set the capacity of the vector to a new value
-        ///
-        /// @warning This may allow writing beyond the allocated memory if used incorrectly!
-        /// @note This requires the data_start pointer be valid.
-        void unsafe_set_capacity(size_t new_capacity) noexcept
-        {
-            static_assert(sizeof(inner) >= 3 * sizeof(pointer));
-            // inner._M_impl._M_end_of_storage = inner._M_impl._M_start + new_capacity;
-        }
     };
 }  // namespace detail
 
@@ -119,20 +167,47 @@ namespace detail {
 ///
 /// @tparam T the element type
 /// @tparam Alloc the allocator type
+///
+/// @note This helper class takes exclusive ownership of the given std::vector for the sole purpose
+/// of leaking its contents. It is not intended to be a general-purpose vector wrapper.
+///
+/// Example usage:
+///
+/// ```cpp
+/// auto vec = std::vector<int>{1, 2, 3, 4};
+/// auto leaky_vec = leaky::Vec<int>(std::move(vec));
+/// auto parts = leaky_vec.leak();
+///
+/// // ...
+///
+/// auto leaky_vec2 = leaky::Vec<int>::from_parts(parts);
+/// auto vec2 = leaky_vec2.take();
+/// ```
 template<typename T, typename Alloc = typename std::vector<T>::allocator_type>
 class Vec
 {
   private:
+    // Hide the yucky pointer math and helper methods, but still enable unit testing them
     detail::VecWrapper<T, Alloc> m_inner;
 
+    Vec(detail::VecWrapper<T, Alloc>&& wrapper) noexcept : m_inner{std::move(wrapper)} {}
+
   public:
+    using pointer = typename std::vector<T, Alloc>::pointer;
+
     /// @brief Create a leaky Vec from a std::vector. Takes exclusive ownership.
-    Vec(std::vector<T, Alloc>&& vec) noexcept : m_inner(std::move(vec)) {}
+    Vec(std::vector<T, Alloc>&& vec) noexcept : m_inner{std::move(vec)} {}
     /// @brief Take exclusive ownership from another leaky Vec.
     Vec(Vec&& other) noexcept : m_inner(std::move(other.m_inner)) {}
     /// @brief A Vec owns the internal vector exclusively; no copying.
     Vec(const Vec&) = delete;
     ~Vec() noexcept = default;
+
+    /// @brief Create a leaky Vec from its raw parts returned by `leak()`
+    static Vec from_parts(std::tuple<pointer, size_t, size_t, Alloc> parts) noexcept
+    {
+        return Vec(std::move(detail::VecWrapper<T, Alloc>::unsafe_from_parts(parts)));
+    }
 
     Vec& operator=(const Vec&) = delete;
     Vec& operator=(Vec&& other) noexcept
@@ -142,13 +217,29 @@ class Vec
     }
 
     /// @brief Take ownership of the std::vector back
-    std::vector<T, Alloc> take() noexcept { return std::move(m_inner); }
+    ///
+    /// @note After calling this method, the internal std::vector is left in an empty state.
+    std::vector<T, Alloc> take() noexcept { return std::move(m_inner.inner); }
     /// @brief Get a const reference to the internal std::vector
-    const std::vector<T, Alloc>& as_ref() const noexcept { return m_inner; }
+    const std::vector<T, Alloc>& as_ref() const noexcept { return m_inner.inner; }
     /// @brief Get a mutable reference to the internal std::vector
-    std::vector<T, Alloc>& as_mut() noexcept { return m_inner; }
+    std::vector<T, Alloc>& as_mut() noexcept { return m_inner.inner; }
 
     /// @brief Get the allocator that owns the vector's memory
-    constexpr Alloc get_allocator() const noexcept { return m_inner.get_allocator(); }
+    [[nodiscard]] constexpr Alloc get_allocator() const noexcept { return m_inner.get_allocator(); }
+
+    /// @brief Leak the internal vector as its raw parts
+    ///
+    /// The tuple contains, in order:
+    /// 1. pointer to the start of the vector's data block
+    /// 2. size of the vector (number of initialized elements)
+    /// 3. capacity of the vector (number of allocated elements)
+    /// 4. the allocator that owns the vector's memory block
+    ///
+    /// @note After calling this method, the internal std::vector is left in an empty state.
+    [[nodiscard]] std::tuple<pointer, size_t, size_t, Alloc> leak() noexcept
+    {
+        return m_inner.leak_into_parts();
+    }
 };  // class Vec
 }  // namespace leaky

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(GTest REQUIRED)
 
-add_executable(leakyvec-tests test-allocators.cpp test-vec-wrapper.cpp)
+add_executable(leakyvec-tests test-allocators.cpp test-leaky-vec.cpp test-vec-wrapper.cpp)
 target_compile_features(leakyvec-tests INTERFACE cxx_std_17)
 target_link_libraries(leakyvec-tests PUBLIC leakyvec)
 target_link_libraries(leakyvec-tests PRIVATE GTest::gmock_main)

--- a/tests/test-leaky-vec.cpp
+++ b/tests/test-leaky-vec.cpp
@@ -1,0 +1,76 @@
+#include "mock-allocator.hpp"
+
+#include <leakyvec/leakyvec.hpp>
+
+#include <gmock/gmock.h>
+
+/// Test that we can leak the memory from a std::vector without freeing it
+TEST(LeakyVecTests, LeakAndDoNotFree)
+{
+    auto alloc = testing::MockAllocator<int>{};  // is a strict mock; any unexpected calls will fail
+
+    EXPECT_CALL(*alloc.mock, allocate(4)).Times(1);                // initial allocation
+    EXPECT_CALL(*alloc.mock, allocate(10)).Times(1);               // allocate 10 on resize
+    EXPECT_CALL(*alloc.mock, deallocate(testing::_, 4)).Times(1);  // deallocate first allocation
+
+    // The 10-capacity allocation was leaked!
+    EXPECT_CALL(*alloc.mock, deallocate(testing::_, 10)).Times(0);
+
+    auto v = std::vector<int, testing::MockAllocator<int>>(4, alloc);
+    v.reserve(10);
+    ASSERT_EQ(v.size(), 4);
+    ASSERT_EQ(v.capacity(), 10);
+    auto leaky_v = leaky::Vec<int, testing::MockAllocator<int>>(std::move(v));
+
+    // Intentional memory leak as a part of the test
+    auto parts = leaky_v.leak();
+    static_cast<void>(parts);
+}
+
+/// Test that we can leak the memory from a std::vector and then manually free it
+TEST(LeakyVecTests, LeakAndManuallyFree)
+{
+    auto alloc = testing::MockAllocator<int>{};
+
+    EXPECT_CALL(*alloc.mock, allocate(4)).Times(1);                // initial allocation
+    EXPECT_CALL(*alloc.mock, allocate(10)).Times(1);               // allocate 10 on resize
+    EXPECT_CALL(*alloc.mock, deallocate(testing::_, 4)).Times(1);  // deallocate first allocation
+
+    // The 10-capacity allocation was freed manually
+    EXPECT_CALL(*alloc.mock, deallocate(testing::_, 10)).Times(1);
+
+    auto v = std::vector<int, testing::MockAllocator<int>>(4, alloc);
+    v.reserve(10);
+    ASSERT_EQ(v.size(), 4);
+    ASSERT_EQ(v.capacity(), 10);
+    auto leaky_v = leaky::Vec<int, testing::MockAllocator<int>>(std::move(v));
+
+    auto parts = leaky_v.leak();
+    auto [data, size, capacity, allocator] = parts;
+
+    allocator.deallocate(data, capacity);
+}
+
+/// Test that we can take apart and reconstruct a leaky Vec from its internals
+TEST(LeakyVecTests, LeakAndReconstruct)
+{
+    auto alloc = testing::MockAllocator<int>{};
+
+    EXPECT_CALL(*alloc.mock, allocate(4)).Times(1);                // initial allocation
+    EXPECT_CALL(*alloc.mock, allocate(10)).Times(1);               // allocate 10 on resize
+    EXPECT_CALL(*alloc.mock, deallocate(testing::_, 4)).Times(1);  // deallocate first allocation
+
+    // The 10-capacity allocation was freed by dropping the reconstructed vector
+    EXPECT_CALL(*alloc.mock, deallocate(testing::_, 10)).Times(1);
+
+    auto v = std::vector<int, testing::MockAllocator<int>>(4, alloc);
+    v.reserve(10);
+    ASSERT_EQ(v.size(), 4);
+    ASSERT_EQ(v.capacity(), 10);
+    auto leaky_v = leaky::Vec<int, testing::MockAllocator<int>>(std::move(v));
+
+    auto parts = leaky_v.leak();
+
+    auto leaky_v2 = leaky::Vec<int, testing::MockAllocator<int>>::from_parts(parts);
+    auto v2 = leaky_v2.take();
+}

--- a/tests/test-vec-wrapper.cpp
+++ b/tests/test-vec-wrapper.cpp
@@ -3,8 +3,11 @@
 
 #include <leakyvec/leakyvec.hpp>
 
+#include <tuple>
+
 #include <gmock/gmock.h>
 
+/// Test contiguous data block pointers for a one-byte type
 TEST(VecWrapperTests, uint8_t)
 {
     auto v = std::vector<uint8_t, testing::LogAllocator<uint8_t>>{1, 2, 3, 4};
@@ -27,6 +30,7 @@ TEST(VecWrapperTests, uint8_t)
     ASSERT_EQ(capacity_end - data_start, 10);
 }
 
+/// Test contiguous data block pointers for a word-sized type
 TEST(VecWrapperTests, uint64_t)
 {
     auto v = std::vector<uint64_t>{1, 2, 3, 4};
@@ -49,7 +53,52 @@ TEST(VecWrapperTests, uint64_t)
     ASSERT_EQ(capacity_end - data_start, 10);
 }
 
-TEST(VecWrapperTests, Setters)
+/// Verify assumptions about the memory layout of a std::vector with the default allocator
+TEST(VecWrapperTests, DefaultAllocMemoryLayout)
+{
+    auto v = std::vector<int>{1, 2, 3, 4};
+    v.reserve(10);
+
+    auto wrapper = leaky::detail::VecWrapper<int>{std::move(v)};
+    ASSERT_EQ(wrapper.get_data_ptr_offset(), 0);
+
+    auto* data_start_ptr = wrapper.get_data_start_ptr();
+    ASSERT_EQ(*data_start_ptr, wrapper.inner.data());
+
+    auto* data_end_ptr = wrapper.get_data_end_ptr();
+    ASSERT_EQ(*data_end_ptr, wrapper.inner.data() + wrapper.inner.size());
+
+    auto* capacity_end_ptr = wrapper.get_capacity_end_ptr();
+    ASSERT_EQ(*capacity_end_ptr, wrapper.inner.data() + wrapper.inner.capacity());
+}
+
+/// Verify assumptions about the memory layout of a std::vector with a custom allocator
+TEST(VecWrapperTests, CustomAllocMemoryLayout)
+{
+    testing::MockAllocator<int> alloc;
+    EXPECT_CALL(*alloc.mock, allocate(4)).Times(1);                 // initial allocation
+    EXPECT_CALL(*alloc.mock, deallocate(testing::_, 4)).Times(1);   // deallocate
+    EXPECT_CALL(*alloc.mock, allocate(10)).Times(1);                // resize
+    EXPECT_CALL(*alloc.mock, deallocate(testing::_, 10)).Times(1);  // drop
+
+    auto v = std::vector<int, testing::MockAllocator<int>>{{1, 2, 3, 4}, alloc};
+    v.reserve(10);
+
+    auto wrapper = leaky::detail::VecWrapper<int, testing::MockAllocator<int>>{std::move(v)};
+    ASSERT_EQ(wrapper.get_data_ptr_offset(), sizeof(alloc) / sizeof(int*));
+
+    auto* data_start_ptr = wrapper.get_data_start_ptr();
+    ASSERT_EQ(*data_start_ptr, wrapper.inner.data());
+
+    auto* data_end_ptr = wrapper.get_data_end_ptr();
+    ASSERT_EQ(*data_end_ptr, wrapper.inner.data() + wrapper.inner.size());
+
+    auto* capacity_end_ptr = wrapper.get_capacity_end_ptr();
+    ASSERT_EQ(*capacity_end_ptr, wrapper.inner.data() + wrapper.inner.capacity());
+}
+
+/// Test that we can set the vector's data pointer, size, and capacity
+TEST(VecWrapperTests, DefaultAllocSetters)
 {
     auto v = std::vector<int>{1, 2, 3, 4};
     v.reserve(10);
@@ -83,7 +132,8 @@ TEST(VecWrapperTests, Setters)
     wrapper.unsafe_set_data_start(original_data_start);
 }
 
-TEST(VecWrapperTests, ToAndFromParts)
+/// Test that we can set the vector's data pointer, size, and capacity
+TEST(VecWrapperTests, CustomAllocSetters)
 {
     testing::MockAllocator<int> alloc;
     EXPECT_CALL(*alloc.mock, allocate(4)).Times(1);                 // initial allocation
@@ -93,23 +143,68 @@ TEST(VecWrapperTests, ToAndFromParts)
 
     auto v = std::vector<int, testing::MockAllocator<int>>{{1, 2, 3, 4}, alloc};
     v.reserve(10);
+    const auto original_capacity = v.capacity();
 
     auto wrapper = leaky::detail::VecWrapper<int, testing::MockAllocator<int>>{std::move(v)};
-    const auto* original_data_start = wrapper.get_data_start();
+    auto* original_data_start = wrapper.get_data_start();
     const auto* original_data_end = wrapper.get_data_end();
     const auto* original_capacity_end = wrapper.get_capacity_end();
 
-    // Orphan the vector's memory; would leak if we left this dangling
-    auto parts = wrapper.leak_into_parts();
+    wrapper.unsafe_set_size(3);
+    ASSERT_EQ(wrapper.inner.size(), 3);
+
+    // Would introduce a memory leak if we left this dangling
+    wrapper.unsafe_set_capacity(3);
+    ASSERT_EQ(wrapper.inner.capacity(), 3);
+
+    wrapper.unsafe_set_capacity(original_capacity);
+    ASSERT_EQ(wrapper.inner.capacity(), original_capacity);
+    ASSERT_EQ(wrapper.get_data_end(), original_data_end - 1);
+    ASSERT_EQ(wrapper.get_capacity_end(), original_capacity_end);
+
+    // Can't deallocate without an explosion, so we have to put it back
+    wrapper.unsafe_set_data_start(original_data_start + 1);
+    ASSERT_EQ(wrapper.inner.data(), original_data_start + 1);
+    ASSERT_EQ(wrapper.get_data_start(), original_data_start + 1);
+
+    wrapper.unsafe_set_data_start(original_data_start);
+}
+
+/// Test that we can take apart and reconstruct the std::vector from its internals
+TEST(VecWrapperTests, ToAndFromParts)
+{
+    testing::MockAllocator<int> alloc;
+    EXPECT_CALL(*alloc.mock, allocate(4)).Times(1);                 // initial allocation
+    EXPECT_CALL(*alloc.mock, deallocate(testing::_, 4)).Times(1);   // deallocate
+    EXPECT_CALL(*alloc.mock, allocate(10)).Times(1);                // resize
+    EXPECT_CALL(*alloc.mock, deallocate(testing::_, 10)).Times(1);  // drop
+
+    auto alloc2 = alloc;  // copy
+    auto parts = std::make_tuple<int*, size_t, size_t, testing::MockAllocator<int>>(
+        nullptr, 0, 0, std::move(alloc2));
+    int* original_data_start = nullptr;
+    int* original_data_end = nullptr;
+    int* original_capacity_end = nullptr;
+
+    {
+        auto v = std::vector<int, testing::MockAllocator<int>>{{1, 2, 3, 4}, alloc};
+        v.reserve(10);
+
+        auto wrapper = leaky::detail::VecWrapper<int, testing::MockAllocator<int>>{std::move(v)};
+        original_data_start = wrapper.get_data_start();
+        original_data_end = wrapper.get_data_end();
+        original_capacity_end = wrapper.get_capacity_end();
+
+        // Orphan the vector's memory; would leak if we left this dangling
+        parts = wrapper.leak_into_parts();
+    }  // The vector is dropped here, but we've kept its memory alive!
 
     // Reconstruct the vector from the original memory parts; should not do any more allocations,
     // and should have the exact same pointers as before;
     auto new_wrapper =
         leaky::detail::VecWrapper<int, testing::MockAllocator<int>>::unsafe_from_parts(parts);
 
-    // BUG: These assertions fail
     ASSERT_EQ(new_wrapper.get_data_start(), original_data_start);
     ASSERT_EQ(new_wrapper.get_data_end(), original_data_end);
     ASSERT_EQ(new_wrapper.get_capacity_end(), original_capacity_end);
-    // BUG: This test doesn't exit?! Maybe shenanigans due to the mock allocator during destruction?
 }


### PR DESCRIPTION
Only tested with libstdc++ on Fedora 42 so far; need to test with at least libc++ and MSVC as well, and build automated tests for those.

Closes #8 